### PR TITLE
Addaptation pour flambda

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -3092,8 +3092,8 @@ let module_map modmap =
     match modmap with
     | None -> Printf.eprintf "   None (flambda)\n%!"
     | Some modmap ->
-      List.iter (fun (pos,id) ->
-        Printf.eprintf "   val  %3d -> %S\n" pos (Ident.name id)) modmap.map;
+      List.iter (fun (pos,symbol,id) ->
+        Printf.eprintf "   val  %s.(%3d) -> %S\n" symbol pos (Ident.name id)) modmap.map;
       List.iter (fun (pos, name) ->
         Printf.eprintf "   prim %3d -> %S\n" pos name
       ) modmap.prims;

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -264,20 +264,23 @@ and lambda_event_kind =
   | Lev_function
   | Lev_pseudo
 
+type symbol = string
+
 type module_map = {
-  map :  (int * Ident.t) list;
+  map :  (int * symbol * Ident.t) list;
   prims : (int * string) list;
-  methcache : int option;
+  methcache : (int * symbol) option;
   size : int;
 }
 
-let module_map ?methcache map prims size =
+let module_map_clambda ~module_name map prims size =
+  let symbol = "caml" ^ module_name in
   let map = Ident.fold_all (fun id (pos, _cc) list ->
-    (pos, id) :: list) map [] in
+    (pos, symbol, id) :: list) map [] in
   let prims = List.map (fun (pos, prim) ->
     pos, prim.Typedtree.pc_desc.Primitive.prim_name
   ) prims in
-  { map; prims; methcache; size }
+  { map; prims; methcache = None; size }
 
 type program =
   { module_ident : Ident.t;

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -281,14 +281,16 @@ and lambda_event_kind =
   | Lev_function
   | Lev_pseudo
 
+type symbol = string
+
 type module_map = {
-  map :  (int * Ident.t) list;
+  map :  (int * symbol * Ident.t) list;
   prims : (int * string) list;
-  methcache : int option;
+  methcache : (int * symbol) option;
   size : int;
 }
 
-val module_map : ?methcache:int ->
+val module_map_clambda : module_name:string ->
            (int * 'a) Ident.tbl ->
            (int * Typedtree.primitive_coercion) list -> int -> module_map
 

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -967,7 +967,7 @@ let transl_store_gen module_name ({ str_items = str }, restr) topl =
         subst_lambda !transl_store_subst (transl_exp expr)
     | str -> transl_store_structure module_id map prims str in
   transl_store_label_init module_id
-    (Lambda.module_map map prims size) f str
+    (Lambda.module_map_clambda ~module_name map prims size) f str
   (*size, transl_label_init (transl_store_structure module_id map prims str)*)
 
 let transl_store_phrases module_name str =
@@ -1155,6 +1155,9 @@ let transl_store_package component_names target_name coercion =
     match arg with
       [] -> lambda_unit
     | hd :: tl -> Lsequence(fn pos hd, make_sequence fn (pos + 1) tl) in
+  let module_map map size =
+    Lambda.module_map_clambda ~module_name:(Ident.name target_name) map [] size
+  in
   match coercion with
     Tcoerce_none ->
       let size, map = List.fold_left (fun (i,map) id ->
@@ -1164,7 +1167,7 @@ let transl_store_package component_names target_name coercion =
         in
         (i+1, map)
       ) (0, Ident.empty) component_names in
-      Lambda.module_map map [] size,
+      module_map map size,
        make_sequence
          (fun pos id ->
            Lprim(Psetfield(pos, Pointer, Initialization),
@@ -1185,7 +1188,7 @@ let transl_store_package component_names target_name coercion =
           Ident.add id (pos, cc) map
         ) Ident.empty id_pos_list
       in
-      (Lambda.module_map map [] size,
+      (module_map map size,
        Llet (Strict, Pgenval, blk,
              apply_coercion Location.none Strict coercion components,
              make_sequence

--- a/bytecomp/translobj.ml
+++ b/bytecomp/translobj.ml
@@ -140,7 +140,7 @@ let transl_store_label_init glob modmap f arg =
     if !method_count = 0 then (modmap, expr) else
       ({ modmap with
         size = modmap.size+1;
-        methcache = Some modmap.size },
+        methcache = Some (modmap.size, "caml" ^ Ident.name glob) },
      Lsequence(
      Lprim(Psetfield(modmap.size, Pointer, Initialization),
            [Lprim(Pgetglobal glob, [], Location.none);


### PR DESCRIPTION
J'ai juste commencé.

Pour l'instant il n'y a que le type module_map qui est changé.
Il va falloir extraire l'info des passes qui le génèrent dans le middle-end.
Il y a plusieurs choix possibles:
- Ajouter dans les types de flambda de quoi identifier quel Ident correspond à quel symbol et à quelle position:
  - Soit  dans Flambda.program_body dans initialize_symbol et let_symbol.
  - Soit retrouver ça à partir des variables définie à partir de Read_symbol_field (probablement le moins de changement)
  
  Pour ça il faut aussi ajouter l'Ident original dans le type Variable
- Sinon il est possible de les extraire au moment du lift en symbol: dans Lift_let_to_initialize_symbol et Lift_constant . Il va falloir faire bien gaffe à ce que rien ne soit perdu.

Le plus simple c'est probablement de reparcourir le code à la fin pour récupérer ça à partir des variables.
